### PR TITLE
profile fetch improvements

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,6 @@
 4) change resource flag so it can be specified multiple times or take a list
 1) discover the correct profile from the instance itself
 1) TEST!
+1) review struct names: currently named so they're exported, should not be
+1) review flag construction. it's been suggested that it either shouldn't be in init, or flag declarations should also be in init
+1) continue to remove os.Exit and log.Fatal from everything but main, and maybe? from main.

--- a/main.go
+++ b/main.go
@@ -201,19 +201,18 @@ func getInstanceMap(terraformState *TerraformState) map[string]ResourceInstance 
 
 func getAwsProfile() ([]string, error) {
 	var p []string
-	if profile == "" {
-		files, err := ioutil.ReadDir(".")
-		if err != nil {
-			return nil, err
-		}
-
-		for _, file := range files {
-			if filepath.Ext(file.Name()) == ".tf" {
-				p = append(p, getProfilesFromFile(file.Name())...)
-			}
-		}
-	} else {
+	if profile != "" {
 		return []string{profile}, nil
+	}
+	files, err := ioutil.ReadDir(".")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		if filepath.Ext(file.Name()) == ".tf" {
+			p = append(p, getProfilesFromFile(file.Name())...)
+		}
 	}
 	return p, nil
 }
@@ -221,16 +220,17 @@ func getAwsProfile() ([]string, error) {
 func validateAwsProfile(p []string) (string, error) {
 	var profile string
 	var err error
-	if len(p) > 1 {
+	switch len(p) {
+	case 0:
+		fmt.Printf("No aws profiles found. Attempting to use default.\n")
+		profile = "default"
+	case 1:
+		profile = p[0]
+	default:
 		profile, err = promptForProfile(p)
 		if err != nil {
 			return "", err
 		}
-	} else if len(p) == 0 {
-		fmt.Printf("No aws profiles found. Attempting to use default.\n")
-		profile = "default"
-	} else {
-		profile = p[0]
 	}
 
 	return profile, nil

--- a/main.go
+++ b/main.go
@@ -199,12 +199,12 @@ func getInstanceMap(terraformState *TerraformState) map[string]ResourceInstance 
 	return instances
 }
 
-func getAwsProfile(c chan string) {
+func getAwsProfile() ([]string, error) {
+	var p []string
 	if profile == "" {
-		var p []string
 		files, err := ioutil.ReadDir(".")
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 
 		for _, file := range files {
@@ -212,18 +212,28 @@ func getAwsProfile(c chan string) {
 				p = append(p, getProfilesFromFile(file.Name())...)
 			}
 		}
-
-		if len(p) > 1 {
-			fmt.Printf("More than one profile found. Please select one from %v\n", p)
-			os.Exit(0)
-		} else if len(p) == 0 {
-			fmt.Printf("No aws profiles found. Attempting to use default.")
-			profile = "default"
-		} else {
-			profile = p[0]
-		}
+	} else {
+		return []string{profile}, nil
 	}
-	c <- profile
+	return p, nil
+}
+
+func validateAwsProfile(p []string) (string, error) {
+	var profile string
+	var err error
+	if len(p) > 1 {
+		profile, err = promptForProfile(p)
+		if err != nil {
+			return "", err
+		}
+	} else if len(p) == 0 {
+		fmt.Printf("No aws profiles found. Attempting to use default.\n")
+		profile = "default"
+	} else {
+		profile = p[0]
+	}
+
+	return profile, nil
 }
 
 func getInstances(ch chan TerraformInstanceResult) {
@@ -257,6 +267,20 @@ func promptForInstance(instances map[string]ResourceInstance) string {
 	return result
 }
 
+func promptForProfile(p []string) (string, error) {
+	prompt := promptui.Select{
+		Label: "Select Profile",
+		Items: p,
+	}
+
+	_, result, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
 func validateInstance(t TerraformInstanceResult) ResourceInstance {
 	if t.Error != nil {
 		fmt.Printf("Something went wrong getting the terraform state.\n")
@@ -285,16 +309,29 @@ func main() {
 	go getInstances(c)
 
 	// grab any profiles from the local terraform files
-	p := make(chan string)
-	go getAwsProfile(p)
+	p := make(chan []string)
+	go func(p chan []string) {
+		s, err := getAwsProfile()
+		if err != nil {
+			fmt.Printf("Error getting aws profile: %v\n", err)
+			os.Exit(1)
+		}
+		p <- s
+	}(p)
 
 	instanceResult := <-c
 	instance := validateInstance(instanceResult)
 
-	profile = <-p
-	fmt.Printf("Unprotecting %s using profile %s.\n", instance.Resource, profile)
+	profileResult := <-p
+	finalProfile, err := validateAwsProfile(profileResult)
+	if err != nil {
+		fmt.Printf("Error validating aws profile: %v\n", err)
+		os.Exit(1)
+	}
 
-	if unprotectInstance(profile, instance) {
+	fmt.Printf("Unprotecting %s using profile %s.\n", instance.Resource, finalProfile)
+
+	if unprotectInstance(finalProfile, instance) {
 		fmt.Printf("Instance %s unprotected.\n", instance.Resource)
 	} else {
 		fmt.Printf("Failed to disable termination protection for %s.", instance.Resource)

--- a/main_test.go
+++ b/main_test.go
@@ -14,3 +14,22 @@ func TestValidateInstance(t *testing.T) {
 		t.Errorf("validateInstance failed. got: %s, want: %s", result.Resource, "myinstance")
 	}
 }
+
+func TestValidateAwsProfile(t *testing.T) {
+	tables := []struct {
+		foundProfiles []string
+		givenProfile  string
+		expected      string
+	}{
+		{[]string{"myprofile"}, "myprofile", "myprofile"},
+		{[]string{}, "", "default"},
+	}
+
+	for _, table := range tables {
+		profile = table.givenProfile
+		result, _ := validateAwsProfile(table.foundProfiles)
+		if result != table.expected {
+			t.Errorf("validateAwsProfile failed. got: %s, want: %s\n", result, table.expected)
+		}
+	}
+}


### PR DESCRIPTION
* Switch goroutine pattern so that the caller is responsible for the
  goroutine
* Move profile determination code into it's own function with prompt
  * remove prompt from possible goroutine
* Add a (probably lame) test for the validate function

This PR is deferring doing testing the hcl read because that seems hard.